### PR TITLE
Update taglib link in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/kode54/dumb.git
 [submodule "taglib/taglib-src"]
 	path = taglib/taglib-src
-	url = git@github.com:taglib/taglib.git
+	url = https://github.com/taglib/taglib.git
 [submodule "ogg/ogg-src"]
 	path = ogg/ogg-src
 	url = https://github.com/xiph/ogg.git


### PR DESCRIPTION
Using https protocol for taglib, as all other submodules do